### PR TITLE
Fixes #24 - using isQueryParams instead of accessing private Ember API

### DIFF
--- a/addon/-private/query-params.js
+++ b/addon/-private/query-params.js
@@ -1,3 +1,0 @@
-import Ember from 'ember';
-
-export default Ember.__loader.require('ember-routing/system/query_params').default;

--- a/addon/helpers/transition-to.js
+++ b/addon/helpers/transition-to.js
@@ -1,5 +1,4 @@
 import Ember from 'ember';
-import QueryParams from '../-private/query-params';
 
 const {
   getOwner
@@ -12,7 +11,7 @@ export default Ember.Helper.extend({
     let router = getOwner(this).lookup('router:main');
     
     let queryParams = params[params.length - 1];
-    if (queryParams instanceof QueryParams) {
+    if (queryParams && queryParams.isQueryParams) {
       params[params.length - 1] = { queryParams: queryParams.values };
     }
 


### PR DESCRIPTION
Use the isQueryParams attribute of QueryParams objects instead of using instanceof the private QueryParams class; #24.