### PR TITLE
fix: dummy rootURL for production builds needs to be set

### DIFF
--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -44,6 +44,8 @@ module.exports = function (environment) {
   }
 
   if (environment === 'production') {
+    ENV.locationType = 'hash';
+    ENV.rootURL = '/ember-reactive-helpers/';
     // here you can enable a production-specific feature
   }
 


### PR DESCRIPTION
properly sets rootURL so that the deployed gh-pages demo app works properly